### PR TITLE
fix nightly errors

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: [1.57.0]
+        msrv: [1.58.0]
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - name: Checkout sources

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Where the tiers refer to:
 
 ## MSRV
 
-The minimal version of rust we support is 1.57.0.
+The minimal version of rust we support is 1.58.0.
 
 ## Installation
 

--- a/fitsio-sys-bindgen/build.rs
+++ b/fitsio-sys-bindgen/build.rs
@@ -35,21 +35,16 @@ fn main() {
             // the PKG_CONFIG_PATH
             let stderr = String::from_utf8(output.stderr).unwrap();
             if stderr.contains::<&str>(
-                format!(
-                    "{} was not found in the pkg-config search path",
-                    package_name
-                )
-                .as_ref(),
+                format!("{package_name} was not found in the pkg-config search path").as_ref(),
             ) {
                 let err_msg = format!(
                     "
-Cannot find {} on the pkg-config search path.  Consider installing the library for your
+Cannot find {package_name} on the pkg-config search path.  Consider installing the library for your
 system (e.g. through homebrew, apt-get etc.).  Alternatively if it is installed, then add
 the directory that contains `cfitsio.pc` on your PKG_CONFIG_PATH, e.g.:
 
 PKG_CONFIG_PATH=<blah> cargo build
-",
-                    package_name
+"
                 );
                 std::io::stderr().write_all(err_msg.as_bytes()).unwrap();
                 std::process::exit(output.status.code().unwrap());

--- a/fitsio-sys/build.rs
+++ b/fitsio-sys/build.rs
@@ -14,21 +14,16 @@ fn bind_cfitsio() {
             // the PKG_CONFIG_PATH
             let stderr = String::from_utf8(output.stderr).unwrap();
             if stderr.contains::<&str>(
-                format!(
-                    "{} was not found in the pkg-config search path",
-                    package_name
-                )
-                .as_ref(),
+                format!("{package_name} was not found in the pkg-config search path").as_ref(),
             ) {
                 let err_msg = format!(
                     "
-Cannot find {} on the pkg-config search path.  Consider installing the library for your
+Cannot find {package_name} on the pkg-config search path.  Consider installing the library for your
 system (e.g. through homebrew, apt-get etc.).  Alternatively if it is installed, then add
 the directory that contains `cfitsio.pc` on your PKG_CONFIG_PATH, e.g.:
 
 PKG_CONFIG_PATH=<blah> cargo build
-",
-                    package_name
+"
                 );
                 std::io::stderr().write_all(err_msg.as_bytes()).unwrap();
                 std::process::exit(output.status.code().unwrap());


### PR DESCRIPTION
Nightly was complaining that we weren't using variables in our strings. Now we are using captured identifiers in format strings[0], but that does mean bumping the MSRV to 1.58 but that is from January of this year so it is fine.

[0]: https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html#captured-identifiers-in-format-strings
