### PR TITLE
fitsio-sys-bindgen now links to cfitsio

### DIFF
--- a/fitsio-sys-bindgen/Cargo.toml
+++ b/fitsio-sys-bindgen/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT/Apache-2.0"
 build = "build.rs"
 documentation = "https://docs.rs/fitsio-sys-bindgen"
 categories = ["external-ffi-bindings", "science"]
+links = "cfitsio"
 
 [dependencies]
 libc = "0.2.0"


### PR DESCRIPTION
This means that if someone includes both fitsio-sys and fitiso-sys-bindgen, they might get a vaguely sensible error message.

Closes #203
