### PR TITLE
use autotools crate for fitsio-sys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ cfitsio.xcodeproj
 /fitsio-sys/ext/cfitsio/config.status
 /fitsio-sys/ext/cfitsio/zlib/*.o
 *.swp
+fitsio-sys/ext/cfitsio/configure.prev
+fitsio-sys/ext/cfitsio/include
+fitsio-sys/ext/cfitsio/lib

--- a/fitsio-sys/Cargo.toml
+++ b/fitsio-sys/Cargo.toml
@@ -22,7 +22,7 @@ bindgen = ["fitsio-sys-bindgen"]
 
 [build-dependencies]
 pkg-config = "0.3.16"
-autotools = "0.2"
+autotools = ">= 0.2.5"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/fitsio-sys/Cargo.toml
+++ b/fitsio-sys/Cargo.toml
@@ -22,6 +22,7 @@ bindgen = ["fitsio-sys-bindgen"]
 
 [build-dependencies]
 pkg-config = "0.3.16"
+autotools = "0.2"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/fitsio-sys/build.rs
+++ b/fitsio-sys/build.rs
@@ -84,6 +84,7 @@ fn bind_cfitsio() {
         .forbid("--enable-static")
         .enable("reentrant", None)
         .cflag(opt_flag)
+        .cflag("-fPIE")
         .insource(true)
         .build();
 

--- a/fitsio-sys/build.rs
+++ b/fitsio-sys/build.rs
@@ -42,6 +42,7 @@ PKG_CONFIG_PATH=<blah> cargo build
 
 #[cfg(feature = "fitsio-src")]
 fn bind_cfitsio() {
+    use autotools::Config;
     use std::env::var;
     use std::path::PathBuf;
 
@@ -65,7 +66,7 @@ fn bind_cfitsio() {
     // Translate rustc optimisation levels to things a C compiler can
     // understand. I don't know if all C compilers agree here, but it should
     // at least work for gcc.
-    let opt_level: String = match var("OPT_LEVEL").as_ref().map(|o| o.as_str()) {
+    let opt_level = match var("OPT_LEVEL").as_ref().map(|o| o.as_str()) {
         Err(_) => panic!("Something wrong with OPT_LEVEL"),
         // gcc doesn't handle 'z'. Just set it to 's', which also optimises
         // for size.
@@ -74,48 +75,19 @@ fn bind_cfitsio() {
     }
     .to_string();
 
-    // Run the contigure script. I'd use the autotools crate here, but it
-    // always outputs two of --{enable,disable}-{shared,static}, none of
-    // which is supported by the cfitsio configure script! So, just run the
-    // script manually.
-    let dst = PathBuf::from(var("OUT_DIR").unwrap());
+    let opt_flag = format!("-O{opt_level}");
 
-    if cfitsio_project_dir.join("Makefile").is_file() {
-        std::process::Command::new("make")
-            .arg("clean")
-            .current_dir(&cfitsio_project_dir)
-            .spawn()
-            .expect("Couldn't run cfitsio make clean")
-            .wait()
-            .expect("Failed to wait on child");
-    }
+    let dst = Config::new("ext/cfitsio")
+        .disable("curl", None)
+        .enable_shared()
+        .forbid("--enable-shared")
+        .forbid("--enable-static")
+        .enable("reentrant", None)
+        .cflag(opt_flag)
+        .insource(true)
+        .build();
 
-    std::process::Command::new("sh")
-        .args(&[
-            "./configure",
-            &format!("--prefix={}", dst.display()),
-            // cfitsio should always be built with reentrant support.
-            "--enable-reentrant",
-            // curl functionality is not used through rust-fitsio.
-            "--disable-curl",
-        ])
-        .env("CFLAGS", &format!("-Wall -O{} -fPIE", opt_level))
-        .current_dir(&cfitsio_project_dir)
-        .spawn()
-        .expect("Couldn't run cfitsio configure script")
-        .wait()
-        .expect("Failed to wait on child");
-
-    std::process::Command::new("make")
-        .arg("-j")
-        .arg("install")
-        .current_dir(&cfitsio_project_dir)
-        .spawn()
-        .expect("Couldn't run cfitsio makefile")
-        .wait()
-        .expect("Failed to wait on child");
-
-    println!("cargo:rustc-link-search=native={}/lib", dst.display());
+    println!("cargo:rustc-link-search=native={}", dst.display());
     println!("cargo:rustc-link-lib=static=cfitsio");
 }
 


### PR DESCRIPTION
We can use the autotools crate to simplify the custom build script.

This is the first part in moving the `fitsio-sys-bindgen` crate inline with `fitsio-sys`.
