### PR TITLE
Fix bad merge from dependabot

### DIFF
--- a/fitsio/Cargo.toml
+++ b/fitsio/Cargo.toml
@@ -28,7 +28,7 @@ libc = "0.2.44"
 ndarray = { version = "0.15.0", optional = true }
 
 [dev-dependencies]
-criterion = "0.5.1"
+criterion = "0.3.5"
 fitsio-derive = { version = "0.2", path = "../fitsio-derive" }
 tempfile = "3.0.0"
 version-sync = "0.9.0"


### PR DESCRIPTION
This branch fixes an invalid merge that was not caught in CI since the failing test was not included in the list of required checks.
