### PR TITLE
Fix clippy lint about Arc<T>

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -33,4 +33,4 @@ jobs:
           components: rustfmt, clippy
 
       - name: Test the code
-        run: python3 ./bin/test --rust-version nightly --test all
+        run: python3 ./bin/test --rust-version nightly --test all --extra-clippy-flags "-A clippy::arc_with_non_send_sync"  # extra clippy args since lint is nightly only for now

--- a/bin/test
+++ b/bin/test
@@ -3,11 +3,11 @@
 
 import subprocess as sp
 import argparse
+import shlex
 import sys
 
 
 def collect_test_options(cls):
-
     tests = []
     for method in dir(cls):
         if method.startswith("_run_test_"):
@@ -30,11 +30,14 @@ class TestRunner:
         sp.check_call(["cargo", f"+{self.rust_version}", "--version"])
         print()
 
-    def run(self, test):
+    def run(self, test: str, extra_clippy_flags: str):
         method = getattr(self, f"_run_test_{test.replace('-', '_')}", None)
         if not method:
             raise NotImplementedError(test)
-        method()
+        if test in {"clippy", "all"}:
+            method(extra_clippy_flags)
+        else:
+            method()
 
     def _run_cargo(self, *args):
         cmd = ["cargo", f"+{self.rust_version}"] + list(args)
@@ -49,8 +52,8 @@ class TestRunner:
     def _run_test_workspace(self):
         self._run_cargo("test")
 
-    def _run_test_clippy(self):
-        self._run_cargo(
+    def _run_test_clippy(self, extra_clippy_flags: str):
+        args = [
             "clippy",
             "--",
             "-D",
@@ -58,17 +61,15 @@ class TestRunner:
             # specific allow of clippy lints
             "-A",
             "clippy::non-send-fields-in-send-ty",
-        )
+        ] + shlex.split(extra_clippy_flags)
+        print(args)
+        self._run_cargo(*args)
 
     def _run_test_full_example(self):
-        self._run_cargo(
-            "run", "--manifest-path", "fitsio/Cargo.toml", "--example", "full_example"
-        )
+        self._run_cargo("run", "--manifest-path", "fitsio/Cargo.toml", "--example", "full_example")
 
     def _run_test_array(self):
-        self._run_cargo(
-            "test", "--manifest-path", "fitsio/Cargo.toml", "--features", "array"
-        )
+        self._run_cargo("test", "--manifest-path", "fitsio/Cargo.toml", "--features", "array")
 
     def _run_test_fitsio_src(self):
         self._run_cargo(
@@ -100,14 +101,17 @@ class TestRunner:
             "--no-default-features",
         )
 
-    def _run_test_all(self):
+    def _run_test_all(self, extra_clippy_flags: str):
         for test_name in self._tests:
             if test_name == "all":
                 continue
 
             method_name = f"_run_test_{test_name.replace('-', '_')}"
             method = getattr(self, method_name)
-            method()
+            if test_name == "clippy":
+                method(extra_clippy_flags)
+            else:
+                method()
 
 
 if __name__ == "__main__":
@@ -125,8 +129,11 @@ if __name__ == "__main__":
         default="all",
         choices=TestRunner._tests,
     )
+    parser.add_argument(
+        "--extra-clippy-flags", required=False, default="", help="Extra flags to run to clippy command"
+    )
     args = parser.parse_args()
 
     runner = TestRunner(args.rust_version)
     runner.print_preamble()
-    runner.run(test=args.test)
+    runner.run(test=args.test, extra_clippy_flags=args.extra_clippy_flags)

--- a/flake.lock
+++ b/flake.lock
@@ -34,31 +34,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1676946801,
-        "narHash": "sha256-OODjEAsnvYyl61HQp8hdIUdr4ItMe2iY1gPzkLy5CXQ=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "f02d590b871a6241dc55d41e799bc530e28214ce",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,33 +4,22 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    rust-overlay.url = "github:oxalica/rust-overlay";
-    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
-    rust-overlay.inputs.flake-utils.follows = "flake-utils";
   };
 
-  outputs = { nixpkgs, flake-utils, rust-overlay, ... }:
+  outputs = { nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        overlays = [
-          rust-overlay.overlays.default
-        ];
-        pkgs = import nixpkgs {
-          inherit overlays system;
-        };
+        pkgs = nixpkgs.legacyPackages.${system};
       in
       {
         devShells.default = pkgs.mkShell rec {
           buildInputs = [
-            pkgs.rust-bin.beta.latest.default
-            pkgs.clippy
-            pkgs.rustfmt
+            pkgs.rustup
             pkgs.libiconv
             pkgs.cfitsio
             pkgs.bzip2
             pkgs.pkg-config
             pkgs.cargo-release
-            pkgs.rust-analyzer
             # for bin/test
             pkgs.python3
           ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "beta"
+components = ["rustfmt", "rust-analyzer", "clippy"]


### PR DESCRIPTION
Fix the following output:

```
Checking fitsio v0.21.2 (/home/runner/work/rust-fitsio/rust-fitsio/fitsio)
error: usage of `Arc<T>` where `T` is not `Send` or `Sync`
  --> fitsio/src/threadsafe_fitsfile.rs:37:28
   |
37 |         ThreadsafeFitsFile(Arc::new(Mutex::new(self)))
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: consider using `Rc<T>` instead or wrapping `T` in a std::sync type like `Mutex<T>`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
   = note: `#[deny(clippy::arc_with_non_send_sync)]` on by default
```

https://github.com/simonrw/rust-fitsio/actions/runs/5441703917/jobs/9895972197#step:5:704
