### PR TITLE
Add clippy feature

### DIFF
--- a/fitsio/Cargo.toml
+++ b/fitsio/Cargo.toml
@@ -39,6 +39,7 @@ serde = "1.0.178"
 array = ["ndarray"]
 bindgen = ["fitsio-sys/with-bindgen"]
 fitsio-src = ["fitsio-sys/fitsio-src"]
+clippy = []
 
 [[bench]]
 harness = false


### PR DESCRIPTION
This fixes recent build errors with nightly as we have to configure a clippy feature specifically.

E.g. https://github.com/simonrw/rust-fitsio/actions/runs/8981350549
