### PR TITLE
chore(deps): group updates and be more selective about CI runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,27 +3,43 @@ updates:
 - package-ecosystem: cargo
   directory: "/fitsio"
   schedule:
-    interval: daily
+    interval: weekly
     time: "11:00"
   open-pull-requests-limit: 10
+  groups:
+    cargo-packages:
+      patterns:
+        - "*"
 - package-ecosystem: cargo
   directory: "/fitsio-derive"
   schedule:
-    interval: daily
+    interval: weekly
     time: "11:00"
   open-pull-requests-limit: 10
+  groups:
+    cargo-packages:
+      patterns:
+        - "*"
 - package-ecosystem: cargo
   directory: "/fitsio-sys"
   schedule:
-    interval: daily
+    interval: weekly
     time: "11:00"
   open-pull-requests-limit: 10
+  groups:
+    cargo-packages:
+      patterns:
+        - "*"
 - package-ecosystem: cargo
   directory: "/fitsio-sys-bindgen"
   schedule:
-    interval: daily
+    interval: weekly
     time: "11:00"
   open-pull-requests-limit: 10
+  groups:
+    cargo-packages:
+      patterns:
+        - "*"
   ignore:
   - dependency-name: bindgen
     versions:
@@ -31,4 +47,8 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+  groups:
+    cargo-packages:
+      patterns:
+        - "*"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,17 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - 'bin/**'
+      - 'fitsio/**'
+      - 'fitsio-derive/**'
+      - 'fitsio-sys/**'
+      - 'testdata/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Cross.toml'
+      - 'rust-toolchain.toml'
+
 
 # Only one pull-request triggered run should be executed at a time
 # (head_ref is only set for PR events, otherwise fallback to run_id which differs for every run).

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,7 @@ on:
       - 'Cargo.lock'
       - 'Cross.toml'
       - 'rust-toolchain.toml'
+      - '.github/workflows/*.yml'
 
 
 # Only one pull-request triggered run should be executed at a time

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,17 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - 'bin/**'
+      - 'fitsio/**'
+      - 'fitsio-derive/**'
+      - 'fitsio-sys/**'
+      - 'testdata/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Cross.toml'
+      - 'rust-toolchain.toml'
+
   workflow_dispatch:
 
 # Only one pull-request triggered run should be executed at a time

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,7 @@ on:
       - 'Cargo.lock'
       - 'Cross.toml'
       - 'rust-toolchain.toml'
+      - '.github/workflows/*.yml'
 
   workflow_dispatch:
 

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -15,6 +15,8 @@ on:
       - 'Cargo.lock'
       - 'Cross.toml'
       - 'rust-toolchain.toml'
+      - '.github/workflows/*.yml'
+
   schedule:
     - cron: "7 7 * * *"
 

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -5,6 +5,16 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - 'bin/**'
+      - 'fitsio/**'
+      - 'fitsio-derive/**'
+      - 'fitsio-sys/**'
+      - 'testdata/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Cross.toml'
+      - 'rust-toolchain.toml'
   schedule:
     - cron: "7 7 * * *"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,16 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - 'bin/**'
+      - 'fitsio/**'
+      - 'fitsio-derive/**'
+      - 'fitsio-sys/**'
+      - 'testdata/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'Cross.toml'
+      - 'rust-toolchain.toml'
 
 # Only one pull-request triggered run should be executed at a time
 # (head_ref is only set for PR events, otherwise fallback to run_id which differs for every run).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ on:
       - 'Cargo.lock'
       - 'Cross.toml'
       - 'rust-toolchain.toml'
+      - '.github/workflows/*.yml'
 
 # Only one pull-request triggered run should be executed at a time
 # (head_ref is only set for PR events, otherwise fallback to run_id which differs for every run).


### PR DESCRIPTION
**Add groups to cargo package updates**

We only want one update PR (per crate) if multiple crates change

**Mark main tests to only run on code changes**

We don't need to run the full test suite on CI configuration changes
