### PR TITLE
chore: release

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,21 @@ stable. Add this to your `Cargo.toml` file:
 
 ```toml,no_sync
 [dependencies]
-fitsio = "0.21.5"
+fitsio = { git = "https://github.com/simonrw/rust-fitsio" }
 ```
 
 If you want the latest release from `crates.io` then add the following:
 
 ```toml
 [dependencies]
-fitsio = "0.21.5"
+fitsio = "*"
 ```
 
 Or pin a specific version:
 
 ```toml
 [dependencies]
-fitsio = "0.21.5"
+fitsio = "0.21.6"
 ```
 
 This repository contains `fitsio-sys-bindgen` which generates the C
@@ -91,7 +91,7 @@ or use from your `Cargo.toml` as such:
 
 ```toml
 [dependencies]
-fitsio = "0.21.5"
+fitsio = "0.21.6"
 ```
 
 ## Documentation

--- a/fitsio-sys/CHANGELOG.md
+++ b/fitsio-sys/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+## [0.5.4](https://github.com/simonrw/rust-fitsio/compare/fitsio-sys-v0.5.3...fitsio-sys-v0.5.4) - 2024-10-31
+
+### Other
+
+- *(deps)* update bindgen requirement from 0.69 to 0.70 in /fitsio-sys in the cargo-packages group ([#357](https://github.com/simonrw/rust-fitsio/pull/357))
+
 ## [0.5.3](https://github.com/simonrw/rust-fitsio/compare/fitsio-sys-v0.5.2...fitsio-sys-v0.5.3) - 2024-07-26
 
 ### Other

--- a/fitsio-sys/Cargo.toml
+++ b/fitsio-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fitsio-sys"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2018"
 authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 description = "FFI wrapper around cfitsio"

--- a/fitsio/CHANGELOG.md
+++ b/fitsio/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.6](https://github.com/simonrw/rust-fitsio/compare/fitsio-v0.21.5...fitsio-v0.21.6) - 2024-10-31
+
+### Added
+
+- add `FitsFile::file_path` method to access `FitsFile` file path ([#367](https://github.com/simonrw/rust-fitsio/pull/367))
+
+### Other
+
+- Allow needless-lifetimes ([#363](https://github.com/simonrw/rust-fitsio/pull/363))
+
 ## [0.21.5](https://github.com/simonrw/rust-fitsio/compare/fitsio-v0.21.4...fitsio-v0.21.5) - 2024-08-06
 
 ### Added

--- a/fitsio/Cargo.toml
+++ b/fitsio/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "fitsio"
 readme = "README.md"
 repository = "https://github.com/simonrw/rust-fitsio"
-version = "0.21.5"
+version = "0.21.6"
 rust-version = "1.58.0"
 
 [package.metadata.release]

--- a/fitsio/src/lib.rs
+++ b/fitsio/src/lib.rs
@@ -1041,7 +1041,7 @@ let _hdu = t.hdu(hdu_num).unwrap();
 [threadsafe-fits-file]: threadsafe_fitsfile/struct.ThreadsafeFitsFile.html
 */
 
-#![doc(html_root_url = "https://docs.rs/fitsio/0.21.5")]
+#![doc(html_root_url = "https://docs.rs/fitsio/0.21.6")]
 #![deny(missing_docs)]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]


### PR DESCRIPTION
## 🤖 New release
* `fitsio`: 0.21.5 -> 0.21.6 (✓ API compatible changes)
* `fitsio-sys`: 0.5.3 -> 0.5.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `fitsio`
<blockquote>

## [0.21.6](https://github.com/simonrw/rust-fitsio/compare/fitsio-v0.21.5...fitsio-v0.21.6) - 2024-10-31

### Added

- add `FitsFile::file_path` method to access `FitsFile` file path ([#367](https://github.com/simonrw/rust-fitsio/pull/367))

### Other

- Allow needless-lifetimes ([#363](https://github.com/simonrw/rust-fitsio/pull/363))
</blockquote>

## `fitsio-sys`
<blockquote>

## [0.5.4](https://github.com/simonrw/rust-fitsio/compare/fitsio-sys-v0.5.3...fitsio-sys-v0.5.4) - 2024-10-31

### Other

- *(deps)* update bindgen requirement from 0.69 to 0.70 in /fitsio-sys in the cargo-packages group ([#357](https://github.com/simonrw/rust-fitsio/pull/357))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).