### PR TITLE
feat: add `FitsFile::file_path` method to access `FitsFile` file path

### DIFF
--- a/fitsio/src/longnam.rs
+++ b/fitsio/src/longnam.rs
@@ -5,12 +5,12 @@
 #![allow(unused_imports, dead_code)]
 
 pub(crate) use crate::sys::{
-    ffclos, ffcopy, ffcrim, ffcrtb, ffdcol, ffdhdu, ffflmd, ffgbcl, ffgcdw, ffgcno, ffgcvb, ffgcvd,
-    ffgcve, ffgcvi, ffgcvj, ffgcvjj, ffgcvk, ffgcvl, ffgcvs, ffgcvsb, ffgcvui, ffgcvuj, ffgcvujj,
-    ffgcvuk, ffgcx, ffghdn, ffghdt, ffgidm, ffgiet, ffgisz, ffgkyd, ffgkye, ffgkyj, ffgkyjj,
-    ffgkyl, ffgkys, ffgncl, ffgnrw, ffgpv, ffgsv, fficol, ffinit, ffmahd, ffmnhd, ffopen, ffpcl,
-    ffpcls, ffpclx, ffphps, ffpky, ffpkyd, ffpkye, ffpkys, ffppr, ffpss, ffrsim, ffthdu, fitsfile,
-    LONGLONG,
+    ffclos, ffcopy, ffcrim, ffcrtb, ffdcol, ffdhdu, ffflmd, ffflnm, ffgbcl, ffgcdw, ffgcno, ffgcvb,
+    ffgcvd, ffgcve, ffgcvi, ffgcvj, ffgcvjj, ffgcvk, ffgcvl, ffgcvs, ffgcvsb, ffgcvui, ffgcvuj,
+    ffgcvujj, ffgcvuk, ffgcx, ffghdn, ffghdt, ffgidm, ffgiet, ffgisz, ffgkyd, ffgkye, ffgkyj,
+    ffgkyjj, ffgkyl, ffgkys, ffgncl, ffgnrw, ffgpv, ffgsv, fficol, ffinit, ffmahd, ffmnhd, ffopen,
+    ffpcl, ffpcls, ffpclx, ffphps, ffpky, ffpkyd, ffpkye, ffpkys, ffppr, ffpss, ffrsim, ffthdu,
+    fitsfile, LONGLONG,
 };
 pub use libc::{
     c_char, c_double, c_float, c_int, c_long, c_schar, c_short, c_uchar, c_uint, c_ulong,
@@ -649,4 +649,12 @@ pub(crate) unsafe fn fits_write_key(
     status: *mut c_int,
 ) -> c_int {
     ffpky(fptr, datatype, keyname, value, comm, status)
+}
+
+pub(crate) unsafe fn fits_file_name(
+    fptr: *mut fitsfile,
+    filename: *mut c_char,
+    status: *mut c_int,
+) -> c_int {
+    ffflnm(fptr, filename, status)
 }


### PR DESCRIPTION
Include a method to access the file path of the `FitsFile`.

During my investigation I found that there was no reason to make it optional. Given this, I have made the field/function return non-optional as well.

Also: it is stored as a `PathBuf` internally, and inherently refers to a path on disk, so let's return a `Path` in that case.

Closes #366 