### PR TITLE
#373 removing x86_64 toolchain dependency for clippy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
 
 RUN rustup update && \
     rustup install stable && \
-    rustup install nightly &&
+    rustup install nightly
 
 VOLUME ["/project"]
 WORKDIR "/project"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ RUN apt-get update && \
 
 RUN rustup update && \
     rustup install stable && \
-    rustup install nightly && \
-    rustup component add clippy --toolchain stable-x86_64-unknown-linux-gnu
+    rustup install nightly &&
 
 VOLUME ["/project"]
 WORKDIR "/project"


### PR DESCRIPTION
Clippy is included by rustup per default and not needed, cf. https://doc.rust-lang.org/clippy/installation.html