### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fitsio"
-version = "0.21.6"
+version = "0.21.7"
 dependencies = [
  "criterion",
  "fitsio-derive",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "fitsio-sys"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "autotools",
  "bindgen",

--- a/fitsio-sys/CHANGELOG.md
+++ b/fitsio-sys/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+## [0.5.5](https://github.com/simonrw/rust-fitsio/compare/fitsio-sys-v0.5.4...fitsio-sys-v0.5.5) - 2025-01-02
+
+### Other
+
+- Simplify build.rs of fitsio-sys ([#377](https://github.com/simonrw/rust-fitsio/pull/377))
+- Include function to get cfitsio version ([#379](https://github.com/simonrw/rust-fitsio/pull/379))
+- *(deps)* update bindgen requirement from 0.70 to 0.71 in /fitsio-sys in the cargo-packages group (#372)
+
 ## [0.5.4](https://github.com/simonrw/rust-fitsio/compare/fitsio-sys-v0.5.3...fitsio-sys-v0.5.4) - 2024-10-31
 
 ### Other

--- a/fitsio-sys/Cargo.toml
+++ b/fitsio-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fitsio-sys"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2018"
 authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 description = "FFI wrapper around cfitsio"

--- a/fitsio/CHANGELOG.md
+++ b/fitsio/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.7](https://github.com/simonrw/rust-fitsio/compare/fitsio-v0.21.6...fitsio-v0.21.7) - 2025-01-02
+
+### Other
+
+- Include function to get cfitsio version ([#379](https://github.com/simonrw/rust-fitsio/pull/379))
+- Fix macos tests ([#380](https://github.com/simonrw/rust-fitsio/pull/380))
+
 ## [0.21.6](https://github.com/simonrw/rust-fitsio/compare/fitsio-v0.21.5...fitsio-v0.21.6) - 2024-10-31
 
 ### Added

--- a/fitsio/Cargo.toml
+++ b/fitsio/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "fitsio"
 readme = "README.md"
 repository = "https://github.com/simonrw/rust-fitsio"
-version = "0.21.6"
+version = "0.21.7"
 rust-version = "1.58.0"
 
 [package.metadata.release]


### PR DESCRIPTION
## 🤖 New release
* `fitsio`: 0.21.6 -> 0.21.7 (✓ API compatible changes)
* `fitsio-sys`: 0.5.4 -> 0.5.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `fitsio`
<blockquote>

## [0.21.7](https://github.com/simonrw/rust-fitsio/compare/fitsio-v0.21.6...fitsio-v0.21.7) - 2025-01-02

### Other

- Include function to get cfitsio version ([#379](https://github.com/simonrw/rust-fitsio/pull/379))
- Fix macos tests ([#380](https://github.com/simonrw/rust-fitsio/pull/380))
</blockquote>

## `fitsio-sys`
<blockquote>

## [0.5.5](https://github.com/simonrw/rust-fitsio/compare/fitsio-sys-v0.5.4...fitsio-sys-v0.5.5) - 2025-01-02

### Other

- Simplify build.rs of fitsio-sys ([#377](https://github.com/simonrw/rust-fitsio/pull/377))
- Include function to get cfitsio version ([#379](https://github.com/simonrw/rust-fitsio/pull/379))
- *(deps)* update bindgen requirement from 0.70 to 0.71 in /fitsio-sys in the cargo-packages group (#372)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).