### PR TITLE
Include function to get cfitsio version

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -52,7 +52,17 @@ class TestRunner:
                 sys.exit(e.returncode)
         print()
 
+    def _print_cfitsio_version_with_features(self, *features: str, default_features: bool = True):
+        cmd = ["cargo", "run", "--package", "fitsio-sys", "--example", "print_version"]
+        for feature in features:
+            cmd.extend(["--features", feature])
+        if not default_features:
+            cmd.append("--no-default-features")
+        print(f"Running {' '.join(cmd)}")
+        sp.check_call(cmd)
+
     def _run_test_workspace(self):
+        self._print_cfitsio_version_with_features()
         self._run_cargo("test", "--locked", "--", "--test-threads", "1")
 
     def _run_test_clippy(self, extra_clippy_flags: str):
@@ -75,6 +85,7 @@ class TestRunner:
         self._run_cargo("test", "--locked", "--manifest-path", "fitsio/Cargo.toml", "--features", "array", "--", "--test-threads", "1")
 
     def _run_test_fitsio_src(self):
+        self._print_cfitsio_version_with_features("fitsio-src")
         self._run_cargo(
             "test",
             "--locked",
@@ -88,6 +99,7 @@ class TestRunner:
         )
 
     def _run_test_fitsio_src_and_bindgen(self):
+        self._print_cfitsio_version_with_features("fitsio-src", "with-bindgen")
         self._run_cargo(
             "test",
             "--locked",
@@ -103,6 +115,7 @@ class TestRunner:
         )
 
     def _run_test_bindgen(self):
+        self._print_cfitsio_version_with_features("with-bindgen", default_features=False)
         self._run_cargo(
             "test",
             "--locked",

--- a/fitsio-sys/examples/print_version.rs
+++ b/fitsio-sys/examples/print_version.rs
@@ -1,0 +1,5 @@
+use fitsio_sys::cfitsio_version;
+
+fn main() {
+    println!("cfitsio version: {}", cfitsio_version());
+}

--- a/fitsio-sys/src/lib.rs
+++ b/fitsio-sys/src/lib.rs
@@ -98,3 +98,29 @@ mod sys {
 }
 
 pub use sys::*;
+
+// global functions
+
+/// Representation of the version of cfitsio used within bindings
+pub struct CfitsioVersion {
+    /// Patch version
+    pub patch: u32,
+    /// Minor version
+    pub minor: u32,
+    /// Major version
+    pub major: u32,
+}
+
+impl std::fmt::Display for CfitsioVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+pub fn cfitsio_version() -> CfitsioVersion {
+    CfitsioVersion {
+        patch: CFITSIO_MICRO,
+        minor: CFITSIO_MINOR,
+        major: CFITSIO_MAJOR,
+    }
+}

--- a/fitsio-sys/src/lib.rs
+++ b/fitsio-sys/src/lib.rs
@@ -103,8 +103,6 @@ pub use sys::*;
 
 /// Representation of the version of cfitsio used within bindings
 pub struct CfitsioVersion {
-    /// Patch version
-    pub patch: u32,
     /// Minor version
     pub minor: u32,
     /// Major version
@@ -113,13 +111,15 @@ pub struct CfitsioVersion {
 
 impl std::fmt::Display for CfitsioVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+        write!(f, "{}.{}", self.major, self.minor)
     }
 }
 
 pub fn cfitsio_version() -> CfitsioVersion {
     CfitsioVersion {
-        patch: CFITSIO_MICRO,
+        // TODO: we need to detect the version of cfitsio we are binding to. Version >=4 supports
+        // this field, but earlier versions don't.
+        // patch: CFITSIO_MICRO,
         minor: CFITSIO_MINOR,
         major: CFITSIO_MAJOR,
     }

--- a/fitsio/src/lib.rs
+++ b/fitsio/src/lib.rs
@@ -1049,6 +1049,9 @@ let _hdu = t.hdu(hdu_num).unwrap();
 
 pub use fitsio_sys as sys;
 
+// re-export version information
+pub use sys::{cfitsio_version, CfitsioVersion};
+
 #[macro_use]
 mod macros;
 mod fitsfile;


### PR DESCRIPTION
We provide an example to print the cfitiso version.

Note: this is designed to work on versions 3+ so we don't support the semver patch version (yet).

We also add running this example before each test that uses features so that we can debug in the future cfitsio versions.
