### PR TITLE
Split out ci for test step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - rust: stable
-          - rust: beta
+        rust: [stable, beta]
+        test: [array, bindgen, clippy, fitsio-src, fitsio-src-and-bindgen, full-example, workspace]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -65,16 +64,15 @@ jobs:
         run: cargo generate-lockfile
 
       - name: Test the code
-        run: python3 ./bin/test --rust-version ${{matrix.rust}} --test all
+        run: python3 ./bin/test --rust-version ${{matrix.rust}} --test ${{matrix.test}}
 
   macos-test:
     runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - rust: stable
-          - rust: beta
+        rust: [stable, beta]
+        test: [array, bindgen, clippy, fitsio-src, fitsio-src-and-bindgen, full-example, workspace]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -103,7 +101,7 @@ jobs:
         run: cargo generate-lockfile
 
       - name: Test the code
-        run: python3 ./bin/test --rust-version ${{matrix.rust}} --test all
+        run: python3 ./bin/test --rust-version ${{matrix.rust}} --test ${{matrix.test}}
 
   linux-armv7:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It would be nice to run the CI tests in parallel, and separetely to get a better overview of what works and what doesn't.

Note: the CI is breaking for an unrelated reason on macos
