### PR TITLE
Replace unimplemented!() with unreachable!()

### DIFF
--- a/fitsio/src/fitsfile.rs
+++ b/fitsio/src/fitsfile.rs
@@ -66,7 +66,7 @@ impl FitsFile {
                 open_mode: FileOpenMode::READONLY,
                 file_path: file_path.to_path_buf(),
             },
-            None => unimplemented!(),
+            None => unreachable!("cfitsio returned success but a null pointer"),
         })
     }
 
@@ -108,7 +108,7 @@ impl FitsFile {
                 open_mode: FileOpenMode::READWRITE,
                 file_path: file_path.to_path_buf(),
             },
-            None => unimplemented!(),
+            None => unreachable!("cfitsio returned success but a null pointer"),
         })
     }
 
@@ -930,7 +930,7 @@ where
                     open_mode: FileOpenMode::READWRITE,
                     file_path: file_path.to_path_buf(),
                 },
-                None => unimplemented!(),
+                None => unreachable!("cfitsio returned success but a null pointer"),
             };
 
             match self.image_description {


### PR DESCRIPTION
## Summary
- Three call sites in `FitsFile::open`, `FitsFile::edit`, and `NewFitsFile::open` used `unimplemented!()` for the case where cfitsio returns success but a null pointer
- This case should be impossible, so `unreachable!()` better conveys the intent
- `unimplemented!()` misleadingly suggested a missing feature

**Stacked on #433**

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)