### PR TITLE
Implement Sync for ThreadsafeFitsFile

### DIFF
--- a/fitsio/src/threadsafe_fitsfile.rs
+++ b/fitsio/src/threadsafe_fitsfile.rs
@@ -24,6 +24,8 @@ pub struct ThreadsafeFitsFile(Arc<Mutex<FitsFile>>);
 // Safety: we explicitly wrap the type in an Arc::Mutex which is threadsafe. The Mutex ensures that
 // only one thread can be modifying the file at once.
 unsafe impl Send for ThreadsafeFitsFile {}
+// Safety: the inner Mutex ensures exclusive access when shared across threads via &ThreadsafeFitsFile.
+unsafe impl Sync for ThreadsafeFitsFile {}
 
 impl FitsFile {
     /**


### PR DESCRIPTION
## Summary
- Only `Send` was manually implemented for `ThreadsafeFitsFile`
- Since the inner `Mutex` ensures exclusive access, `Sync` is also safe
- Without `Sync`, `&ThreadsafeFitsFile` cannot be shared between threads (e.g. stored in `Arc` for shared references or used with `rayon` parallel iterators)

## Test plan
- [x] All existing tests pass (including the 10,000-thread stress test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)