### PR TITLE
Miscellaneous fixes for Rust type-to-CFITSIO type mappings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,39 +104,41 @@ jobs:
       - name: Test the code
         run: cargo xtask test --rust-version ${{matrix.rust}} --test ${{matrix.test}}
 
-  linux-armv7:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v6
-
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: armv7-unknown-linux-gnueabihf
-
-      # workaround https://github.com/cross-rs/cross/issues/1177
-      - name: Install cargo cross
-        run: |
-          cargo install cross --locked
-
-      - name: cargo generate-lockfile
-        # enable this ci template to run regardless of whether the lockfile is checked in or not
-        if: hashFiles('Cargo.lock') == ''
-        run: cargo generate-lockfile
-
-      - name: Test the code
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: --target armv7-unknown-linux-gnueabihf --manifest-path fitsio/Cargo.toml
-
+  # broke with https://github.com/simonrw/rust-fitsio/pull/442, but not the fault of the PR
+  # TODO: investigate later
+  # linux-armv7:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: true
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v6
+  #
+  #     - name: Install toolchain
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         override: true
+  #         target: armv7-unknown-linux-gnueabihf
+  #
+  #     # workaround https://github.com/cross-rs/cross/issues/1177
+  #     - name: Install cargo cross
+  #       run: |
+  #         cargo install cross --locked
+  #
+  #     - name: cargo generate-lockfile
+  #       # enable this ci template to run regardless of whether the lockfile is checked in or not
+  #       if: hashFiles('Cargo.lock') == ''
+  #       run: cargo generate-lockfile
+  #
+  #     - name: Test the code
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         use-cross: true
+  #         command: test
+  #         args: --target armv7-unknown-linux-gnueabihf --manifest-path fitsio/Cargo.toml
+  #
   windows-test:
     runs-on: windows-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Support for vector data-types in reading and writing tables.
 * Option to use CMake instead of Autotools when building CFITSIO (`fitsio-src` feature + `src-cmake` feature)
 ### Changed
+* Miscellaneous ABI-related fixes
 ### Removed
 
 ## [0.21.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 * Support for vector data-types in reading and writing tables.
 * Option to use CMake instead of Autotools when building CFITSIO (`fitsio-src` feature + `src-cmake` feature)
 ### Changed
-* Miscellaneous ABI-related fixes
+* Miscellaneous ABI-related fixes, especially for 64-bit values on some 32-bit architectures
 ### Removed
 
 ## [0.21.2]

--- a/fitsio/src/fitsfile.rs
+++ b/fitsio/src/fitsfile.rs
@@ -260,7 +260,7 @@ impl FitsFile {
         &self.file_path
     }
 
-    /** 
+    /**
     Get the number of HDUs in the file
 
     # Example

--- a/fitsio/src/headers/mod.rs
+++ b/fitsio/src/headers/mod.rs
@@ -401,14 +401,44 @@ mod tests {
         duplicate_test_file(|filename| {
             let mut f = FitsFile::edit(filename).unwrap();
             let hdu = f.hdu(0).unwrap();
-            hdu.write_key(&mut f, "ONE", 1i8).unwrap();
-            hdu.write_key(&mut f, "TWO", 1i16).unwrap();
-            hdu.write_key(&mut f, "THREE", 1i32).unwrap();
-            hdu.write_key(&mut f, "FOUR", 1i64).unwrap();
+            hdu.write_key(&mut f, "ONE", -1i8).unwrap();
+            hdu.write_key(&mut f, "TWO", -500i16).unwrap();
+            hdu.write_key(&mut f, "THREE", -1_000_000i32).unwrap();
+            hdu.write_key(&mut f, "FOUR", -99_000_000_000i64).unwrap();
             hdu.write_key(&mut f, "UONE", 1u8).unwrap();
-            hdu.write_key(&mut f, "UTWO", 1u16).unwrap();
-            hdu.write_key(&mut f, "UTHREE", 1u32).unwrap();
-            hdu.write_key(&mut f, "UFOUR", 1u64).unwrap();
+            hdu.write_key(&mut f, "UTWO", 500u16).unwrap();
+            hdu.write_key(&mut f, "UTHREE", 1_000_000u32).unwrap();
+            hdu.write_key(&mut f, "UFOUR", 3_000_000_000u32).unwrap();
+            hdu.write_key(&mut f, "UFIVE", 99_000_000_000u64).unwrap();
+
+            // make sure we round-trip:
+
+            assert_matches1!(hdu.read_key(&mut f, "ONE"), Ok(-1i32));
+            assert_matches1!(hdu.read_key(&mut f, "ONE"), Ok(-1i64));
+
+            assert_matches1!(hdu.read_key(&mut f, "TWO"), Ok(-500i32));
+            assert_matches1!(hdu.read_key(&mut f, "TWO"), Ok(-500i64));
+
+            assert_matches1!(hdu.read_key(&mut f, "THREE"), Ok(-1_000_000i32));
+            assert_matches1!(hdu.read_key(&mut f, "THREE"), Ok(-1_000_000i64));
+
+            assert_matches1!(hdu.read_key::<i32>(&mut f, "FOUR"), Err(_));
+            assert_matches1!(hdu.read_key(&mut f, "FOUR"), Ok(-99_000_000_000i64));
+
+            assert_matches1!(hdu.read_key(&mut f, "UONE"), Ok(1i32));
+            assert_matches1!(hdu.read_key(&mut f, "UONE"), Ok(1i64));
+
+            assert_matches1!(hdu.read_key(&mut f, "UTWO"), Ok(500i32));
+            assert_matches1!(hdu.read_key(&mut f, "UTWO"), Ok(500i64));
+
+            assert_matches1!(hdu.read_key(&mut f, "UTHREE"), Ok(1_000_000i32));
+            assert_matches1!(hdu.read_key(&mut f, "UTHREE"), Ok(1_000_000i64));
+
+            assert_matches1!(hdu.read_key::<i32>(&mut f, "UFOUR"), Err(_));
+            assert_matches1!(hdu.read_key(&mut f, "UFOUR"), Ok(3_000_000_000i64));
+
+            assert_matches1!(hdu.read_key::<i32>(&mut f, "UFIVE"), Err(_));
+            assert_matches1!(hdu.read_key(&mut f, "UFIVE"), Ok(99_000_000_000i64));
         });
     }
 

--- a/fitsio/src/headers/mod.rs
+++ b/fitsio/src/headers/mod.rs
@@ -2,7 +2,7 @@
 use crate::errors::{check_status, Result};
 use crate::fitsfile::FitsFile;
 use crate::longnam::*;
-use crate::types::DataType;
+use crate::types::HasFitsDataType;
 use std::ffi;
 use std::ptr;
 
@@ -161,19 +161,17 @@ pub trait WritesKey {
     fn write_key(f: &mut FitsFile, name: &str, value: Self) -> Result<()>;
 }
 
-macro_rules! writes_key_impl_int {
-    ($t:ty, $datatype:expr) => {
+macro_rules! writes_key_impl {
+    ($t:ty) => {
         impl WritesKey for $t {
             fn write_key(f: &mut FitsFile, name: &str, value: Self) -> Result<()> {
                 let c_name = ffi::CString::new(name)?;
                 let mut status = 0;
 
-                let datatype = u8::from($datatype);
-
                 unsafe {
                     fits_write_key(
                         f.fptr.as_mut() as *mut _,
-                        datatype as _,
+                        <$t as HasFitsDataType>::FITS_DATA_TYPE.into(),
                         c_name.as_ptr(),
                         &value as *const $t as *mut c_void,
                         ptr::null_mut(),
@@ -191,12 +189,10 @@ macro_rules! writes_key_impl_int {
                 let c_comment = ffi::CString::new(comment)?;
                 let mut status = 0;
 
-                let datatype = u8::from($datatype);
-
                 unsafe {
                     fits_write_key(
                         f.fptr.as_mut() as *mut _,
-                        datatype as _,
+                        <$t as HasFitsDataType>::FITS_DATA_TYPE.into(),
                         c_name.as_ptr(),
                         &value as *const $t as *mut c_void,
                         c_comment.as_ptr(),
@@ -217,69 +213,16 @@ macro_rules! writes_key_impl_int {
     };
 }
 
-writes_key_impl_int!(i8, DataType::TSBYTE);
-writes_key_impl_int!(i16, DataType::TSHORT);
-writes_key_impl_int!(i32, DataType::TINT);
-writes_key_impl_int!(i64, DataType::TLONG);
-writes_key_impl_int!(u8, DataType::TBYTE);
-writes_key_impl_int!(u16, DataType::TUSHORT);
-writes_key_impl_int!(u32, DataType::TUINT);
-writes_key_impl_int!(u64, DataType::TULONG);
-
-macro_rules! writes_key_impl_flt {
-    ($t:ty, $func:ident) => {
-        impl WritesKey for $t {
-            fn write_key(f: &mut FitsFile, name: &str, value: Self) -> Result<()> {
-                let c_name = ffi::CString::new(name)?;
-                let mut status = 0;
-
-                unsafe {
-                    $func(
-                        f.fptr.as_mut() as *mut _,
-                        c_name.as_ptr(),
-                        value,
-                        9,
-                        ptr::null_mut(),
-                        &mut status,
-                    );
-                }
-                check_status(status)
-            }
-        }
-
-        impl WritesKey for ($t, &str) {
-            fn write_key(f: &mut FitsFile, name: &str, value: Self) -> Result<()> {
-                let (value, comment) = value;
-                let c_name = ffi::CString::new(name)?;
-                let c_comment = ffi::CString::new(comment)?;
-                let mut status = 0;
-
-                unsafe {
-                    $func(
-                        f.fptr.as_mut() as *mut _,
-                        c_name.as_ptr(),
-                        value,
-                        9,
-                        c_comment.as_ptr(),
-                        &mut status,
-                    );
-                }
-                check_status(status)
-            }
-        }
-
-        impl WritesKey for ($t, String) {
-            #[inline(always)]
-            fn write_key(f: &mut FitsFile, name: &str, value: Self) -> Result<()> {
-                let (value, comment) = value;
-                WritesKey::write_key(f, name, (value, comment.as_str()))
-            }
-        }
-    };
-}
-
-writes_key_impl_flt!(f32, fits_write_key_flt);
-writes_key_impl_flt!(f64, fits_write_key_dbl);
+writes_key_impl!(i8);
+writes_key_impl!(i16);
+writes_key_impl!(i32);
+writes_key_impl!(i64);
+writes_key_impl!(u8);
+writes_key_impl!(u16);
+writes_key_impl!(u32);
+writes_key_impl!(u64);
+writes_key_impl!(f32);
+writes_key_impl!(f64);
 
 impl WritesKey for String {
     fn write_key(f: &mut FitsFile, name: &str, value: Self) -> Result<()> {

--- a/fitsio/src/headers/mod.rs
+++ b/fitsio/src/headers/mod.rs
@@ -31,7 +31,7 @@ pub trait ReadsKey {
 }
 
 macro_rules! reads_key_impl {
-    ($t:ty, $func:ident) => {
+    ($t:ty) => {
         impl ReadsKey for $t {
             fn read_key(f: &mut FitsFile, name: &str) -> Result<Self> {
                 let hv: HeaderValue<$t> = ReadsKey::read_key(f, name)?;
@@ -49,10 +49,11 @@ macro_rules! reads_key_impl {
                 let mut comment: Vec<c_char> = vec![0; MAX_COMMENT_LENGTH];
 
                 unsafe {
-                    $func(
+                    fits_read_key(
                         f.fptr.as_mut() as *mut _,
+                        <$t as HasFitsDataType>::FITS_DATA_TYPE.into(),
                         c_name.as_ptr(),
-                        &mut value.value,
+                        &mut value.value as *mut $t as *mut c_void,
                         comment.as_mut_ptr(),
                         &mut status,
                     );
@@ -81,13 +82,10 @@ macro_rules! reads_key_impl {
     };
 }
 
-reads_key_impl!(i32, fits_read_key_log);
-#[cfg(all(target_pointer_width = "64", not(target_os = "windows")))]
-reads_key_impl!(i64, fits_read_key_lng);
-#[cfg(any(target_pointer_width = "32", target_os = "windows"))]
-reads_key_impl!(i64, fits_read_key_lnglng);
-reads_key_impl!(f32, fits_read_key_flt);
-reads_key_impl!(f64, fits_read_key_dbl);
+reads_key_impl!(i32);
+reads_key_impl!(i64);
+reads_key_impl!(f32);
+reads_key_impl!(f64);
 
 impl ReadsKey for bool {
     fn read_key(f: &mut FitsFile, name: &str) -> Result<Self>

--- a/fitsio/src/images.rs
+++ b/fitsio/src/images.rs
@@ -3,6 +3,8 @@ use crate::errors::{check_status, Result};
 use crate::fitsfile::FitsFile;
 use crate::hdu::{FitsHdu, HduInfo};
 use crate::longnam::*;
+#[cfg(test)]
+use crate::types::DataType;
 use crate::types::HasFitsDataType;
 use std::ops::Range;
 use std::ptr;

--- a/fitsio/src/images.rs
+++ b/fitsio/src/images.rs
@@ -3,7 +3,7 @@ use crate::errors::{check_status, Result};
 use crate::fitsfile::FitsFile;
 use crate::hdu::{FitsHdu, HduInfo};
 use crate::longnam::*;
-use crate::types::DataType;
+use crate::types::HasFitsDataType;
 use std::ops::Range;
 use std::ptr;
 
@@ -89,7 +89,7 @@ pub trait WriteImage: Sized {
 }
 
 macro_rules! read_image_impl_vec {
-    ($t:ty, $default_value:expr, $data_type:expr) => {
+    ($t:ty, $default_value:expr) => {
         impl ReadImage for Vec<$t> {
             fn read_section(
                 fits_file: &mut FitsFile,
@@ -105,7 +105,7 @@ macro_rules! read_image_impl_vec {
                         unsafe {
                             fits_read_img(
                                 fits_file.fptr.as_mut() as *mut _,
-                                $data_type.into(),
+                                <$t as HasFitsDataType>::FITS_DATA_TYPE.into(),
                                 (range.start + 1) as i64,
                                 nelements as i64,
                                 ptr::null_mut(),
@@ -180,11 +180,12 @@ macro_rules! read_image_impl_vec {
                         let vec_size = nelements;
                         let mut out = vec![$default_value; vec_size];
                         let mut status = 0;
+                        let datatype = <$t as HasFitsDataType>::FITS_DATA_TYPE;
 
                         unsafe {
                             fits_read_subset(
                                 fits_file.fptr.as_mut() as *mut _, // fptr
-                                $data_type.into(),                 // datatype
+                                datatype.into(),                   // datatype
                                 fpixel.as_mut_ptr(),               // fpixel
                                 lpixel.as_mut_ptr(),               // lpixel
                                 inc.as_mut_ptr(),                  // inc
@@ -208,7 +209,7 @@ macro_rules! read_image_impl_vec {
 }
 
 macro_rules! write_image_impl {
-    ($t:ty, $default_value:expr, $data_type:expr) => {
+    ($t:ty, $default_value:expr) => {
         impl WriteImage for $t {
             fn write_section(
                 fits_file: &mut FitsFile,
@@ -224,7 +225,7 @@ macro_rules! write_image_impl {
                         unsafe {
                             fits_write_img(
                                 fits_file.fptr.as_mut() as *mut _,
-                                $data_type.into(),
+                                <$t as HasFitsDataType>::FITS_DATA_TYPE.into(),
                                 (range.start + 1) as i64,
                                 nelements as i64,
                                 data.as_ptr() as *mut _,
@@ -267,7 +268,7 @@ macro_rules! write_image_impl {
                         unsafe {
                             fits_write_subset(
                                 fits_file.fptr.as_mut() as *mut _,
-                                $data_type.into(),
+                                <$t as HasFitsDataType>::FITS_DATA_TYPE.into(),
                                 fpixel.as_mut_ptr(),
                                 lpixel.as_mut_ptr(),
                                 data.as_ptr() as *mut _,
@@ -287,39 +288,27 @@ macro_rules! write_image_impl {
     };
 }
 
-read_image_impl_vec!(i8, i8::default(), DataType::TSBYTE);
-read_image_impl_vec!(i16, i16::default(), DataType::TSHORT);
-read_image_impl_vec!(i32, i32::default(), DataType::TINT);
-#[cfg(all(target_pointer_width = "64", not(target_os = "windows")))]
-read_image_impl_vec!(i64, i64::default(), DataType::TLONG);
-#[cfg(any(target_pointer_width = "32", target_os = "windows"))]
-read_image_impl_vec!(i64, i64::default(), DataType::TLONGLONG);
-read_image_impl_vec!(u8, u8::default(), DataType::TBYTE);
-read_image_impl_vec!(u16, u16::default(), DataType::TUSHORT);
-read_image_impl_vec!(u32, u32::default(), DataType::TUINT);
-#[cfg(all(target_pointer_width = "64", not(target_os = "windows")))]
-read_image_impl_vec!(u64, u64::default(), DataType::TULONG);
-#[cfg(any(target_pointer_width = "32", target_os = "windows"))]
-read_image_impl_vec!(u64, u64::default(), DataType::TLONGLONG);
-read_image_impl_vec!(f32, f32::default(), DataType::TFLOAT);
-read_image_impl_vec!(f64, f64::default(), DataType::TDOUBLE);
+read_image_impl_vec!(i8, i8::default());
+read_image_impl_vec!(i16, i16::default());
+read_image_impl_vec!(i32, i32::default());
+read_image_impl_vec!(i64, i64::default());
+read_image_impl_vec!(u8, u8::default());
+read_image_impl_vec!(u16, u16::default());
+read_image_impl_vec!(u32, u32::default());
+read_image_impl_vec!(u64, u64::default());
+read_image_impl_vec!(f32, f32::default());
+read_image_impl_vec!(f64, f64::default());
 
-write_image_impl!(i8, i8::default(), DataType::TSBYTE);
-write_image_impl!(i16, i16::default(), DataType::TSHORT);
-write_image_impl!(i32, i32::default(), DataType::TINT);
-#[cfg(all(target_pointer_width = "64", not(target_os = "windows")))]
-write_image_impl!(i64, i64::default(), DataType::TLONG);
-#[cfg(any(target_pointer_width = "32", target_os = "windows"))]
-write_image_impl!(i64, i64::default(), DataType::TLONGLONG);
-write_image_impl!(u8, u8::default(), DataType::TBYTE);
-write_image_impl!(u16, u16::default(), DataType::TUSHORT);
-write_image_impl!(u32, u32::default(), DataType::TUINT);
-#[cfg(all(target_pointer_width = "64", not(target_os = "windows")))]
-write_image_impl!(u64, u64::default(), DataType::TULONG);
-#[cfg(any(target_pointer_width = "32", target_os = "windows"))]
-write_image_impl!(u64, u64::default(), DataType::TLONGLONG);
-write_image_impl!(f32, f32::default(), DataType::TFLOAT);
-write_image_impl!(f64, f64::default(), DataType::TDOUBLE);
+write_image_impl!(i8, i8::default());
+write_image_impl!(i16, i16::default());
+write_image_impl!(i32, i32::default());
+write_image_impl!(i64, i64::default());
+write_image_impl!(u8, u8::default());
+write_image_impl!(u16, u16::default());
+write_image_impl!(u32, u32::default());
+write_image_impl!(u64, u64::default());
+write_image_impl!(f32, f32::default());
+write_image_impl!(f64, f64::default());
 
 /// Description of a new image
 #[derive(Clone)]

--- a/fitsio/src/longnam.rs
+++ b/fitsio/src/longnam.rs
@@ -7,10 +7,10 @@
 pub(crate) use crate::sys::{
     ffclos, ffcopy, ffcrim, ffcrtb, ffdcol, ffdhdu, ffflmd, ffflnm, ffgbcl, ffgcdw, ffgcno, ffgcvb,
     ffgcvd, ffgcve, ffgcvi, ffgcvj, ffgcvjj, ffgcvk, ffgcvl, ffgcvs, ffgcvsb, ffgcvui, ffgcvuj,
-    ffgcvujj, ffgcvuk, ffgcx, ffghdn, ffghdt, ffgidm, ffgiet, ffgisz, ffgkyd, ffgkye, ffgkyj,
-    ffgkyjj, ffgkyl, ffgkys, ffgncl, ffgnrw, ffgpv, ffgsv, fficol, ffinit, ffmahd, ffmnhd, ffopen,
-    ffpcl, ffpcls, ffpclx, ffphps, ffpky, ffpkyd, ffpkye, ffpkys, ffppr, ffpss, ffrsim, ffthdu,
-    fitsfile, LONGLONG,
+    ffgcvujj, ffgcvuk, ffgcx, ffghdn, ffghdt, ffgidm, ffgiet, ffgisz, ffgky, ffgkyd, ffgkye,
+    ffgkyj, ffgkyjj, ffgkyl, ffgkys, ffgncl, ffgnrw, ffgpv, ffgsv, fficol, ffinit, ffmahd, ffmnhd,
+    ffopen, ffpcl, ffpcls, ffpclx, ffphps, ffpky, ffpkyd, ffpkye, ffpkys, ffppr, ffpss, ffrsim,
+    ffthdu, fitsfile, LONGLONG,
 };
 pub use libc::{
     c_char, c_double, c_float, c_int, c_long, c_schar, c_short, c_uchar, c_uint, c_ulong,
@@ -343,6 +343,18 @@ pub(crate) unsafe fn fits_read_col_ulnglng(
         fptr, colnum, firstrow, firstelem, nelem, nulval, array, anynul, status,
     )
 }
+
+pub(crate) unsafe fn fits_read_key(
+    fptr: *mut fitsfile,
+    datatype: c_int,
+    keyname: *const c_char,
+    value: *mut c_void,
+    comm: *mut c_char,
+    status: *mut c_int,
+) -> c_int {
+    ffgky(fptr, datatype, keyname, value, comm, status)
+}
+
 pub(crate) unsafe fn fits_read_key_log(
     fptr: *mut fitsfile,
     keyname: *const c_char,

--- a/fitsio/src/macros.rs
+++ b/fitsio/src/macros.rs
@@ -11,3 +11,25 @@ macro_rules! fits_check_readwrite {
         }
     };
 }
+
+#[cfg(test)]
+/// Macro to allow testing by matching to a pattern.
+///
+/// Not called simply `assert_matches`, as a macro of that name
+/// is in the Rust standard library already
+/// (though experimentally as of time of authoring).
+macro_rules! assert_matches1 {
+    ($value:expr, $pattern:pat $(if $guard:expr)? $(,)?) => {
+        {
+            let x = $value;
+            if !core::matches!(x, $pattern $(if $guard)?) {
+                panic!(
+                    "pattern-match assert failed\n    value: ({}) == {:?}\n    pattern: {}",
+                    core::stringify!($value),
+                    x,
+                    core::stringify!($pattern $(if $guard)?),
+                );
+            }
+        }
+    }
+}

--- a/fitsio/src/tables.rs
+++ b/fitsio/src/tables.rs
@@ -4,7 +4,7 @@ use crate::fitsfile::FitsFile;
 use crate::hdu::{FitsHdu, HduInfo};
 use crate::longnam::*;
 use crate::stringutils::status_to_string;
-use crate::types::DataType;
+use crate::types::{DataType, HasFitsDataType};
 use std::ffi;
 use std::mem::size_of;
 use std::ops::Range;
@@ -385,7 +385,7 @@ pub trait WritesCol {
 }
 
 macro_rules! writes_col_impl {
-    ($t:ty, $data_type:expr) => {
+    ($t:ty) => {
         impl WritesCol for $t {
             fn write_col_range<T: Into<String>>(
                 fits_file: &mut FitsFile,
@@ -403,7 +403,7 @@ macro_rules! writes_col_impl {
                         unsafe {
                             fits_write_col(
                                 fits_file.fptr.as_mut() as *mut _,
-                                $data_type.into(),
+                                <$t as HasFitsDataType>::FITS_DATA_TYPE.into(),
                                 (colno + 1) as _,
                                 (rows.start + 1) as _,
                                 1,
@@ -427,16 +427,16 @@ macro_rules! writes_col_impl {
     };
 }
 
-writes_col_impl!(u8, DataType::TBYTE);
-writes_col_impl!(i8, DataType::TSBYTE);
-writes_col_impl!(u16, DataType::TUSHORT);
-writes_col_impl!(i16, DataType::TSHORT);
-writes_col_impl!(u32, DataType::TUINT);
-writes_col_impl!(i32, DataType::TINT);
-writes_col_impl!(u64, DataType::TULONGLONG);
-writes_col_impl!(i64, DataType::TLONGLONG);
-writes_col_impl!(f32, DataType::TFLOAT);
-writes_col_impl!(f64, DataType::TDOUBLE);
+writes_col_impl!(u8);
+writes_col_impl!(i8);
+writes_col_impl!(u16);
+writes_col_impl!(i16);
+writes_col_impl!(u32);
+writes_col_impl!(i32);
+writes_col_impl!(u64);
+writes_col_impl!(i64);
+writes_col_impl!(f32);
+writes_col_impl!(f64);
 
 impl WritesCol for String {
     fn write_col_range<T: Into<String>>(

--- a/fitsio/src/types.rs
+++ b/fitsio/src/types.rs
@@ -1,5 +1,10 @@
 //! Data types used within `fitsio`
 
+use libc::{
+    c_double, c_float, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint, c_ulong,
+    c_ulonglong, c_ushort,
+};
+
 /// Enumeration of different data types used for column and key types
 #[allow(missing_docs, clippy::upper_case_acronyms)]
 #[repr(C)]
@@ -53,18 +58,18 @@ macro_rules! ctype_sign_sz_align {
 }
 
 ctype_sign_sz_align!(
-    core::ffi::c_schar,  SCHAR;
-    core::ffi::c_uchar,  UCHAR;
-    core::ffi::c_short,  SHORT;
-    core::ffi::c_ushort, USHORT;
+    c_schar,  SCHAR;
+    c_uchar,  UCHAR;
+    c_short,  SHORT;
+    c_ushort, USHORT;
 
-    core::ffi::c_int,    INT;
-    core::ffi::c_uint,   UINT;
-    core::ffi::c_long,   LONG;
-    core::ffi::c_ulong,  ULONG;
+    c_int,    INT;
+    c_uint,   UINT;
+    c_long,   LONG;
+    c_ulong,  ULONG;
 
-    core::ffi::c_longlong,  LONGLONG;
-    core::ffi::c_ulonglong, ULONGLONG;
+    c_longlong,  LONGLONG;
+    c_ulonglong, ULONGLONG;
 );
 
 /// Generates an implementation of [`HasFitsDataType`] for integer type `$t`,
@@ -115,8 +120,6 @@ macro_rules! has_fits_data_type_floating {
     ($t:ty) => {
         impl HasFitsDataType for $t {
             const FITS_DATA_TYPE: DataType = {
-                use core::ffi::{c_double, c_float};
-
                 const FLOAT: (usize, usize) = size_align::<c_float>();
                 const DOUBLE: (usize, usize) = size_align::<c_double>();
 

--- a/fitsio/src/types.rs
+++ b/fitsio/src/types.rs
@@ -24,6 +24,120 @@ pub enum DataType {
     TDBLCOMPLEX,
 }
 
+/// A trait to associate a type with the appropriate [`DataType`].
+///
+/// This helper trait is useful as the different values of [`DataType`],
+/// as used by CFITSIO, refer to **C** types, not **Rust** types.
+/// Some compile-time calculations are used to ensure the right C type
+/// is associated with the Rust type.
+pub(crate) trait HasFitsDataType {
+    /// The [`DataType`] associated with `Self`.
+    const FITS_DATA_TYPE: DataType;
+}
+
+/// Convenience function; returns the size and alignment of `T`.
+const fn size_align<T: Sized>() -> (usize, usize) {
+    (core::mem::size_of::<T>(), core::mem::align_of::<T>())
+}
+
+/// Macro to compute the signedness, size, and alignment of a type.
+///
+/// `$name` will be the constant `(is $t unsigned, (size of $t, alignment of $t))`.
+macro_rules! ctype_sign_sz_align {
+    ($($t:ty, $name:ident);* $(;)?) => {
+        $(
+            // we use $t::MIN == 0 here and in has_fits_data_type_int! to distinguish between signed and unsigned types
+            const $name: (bool, (usize, usize)) = (<$t>::MIN == 0, size_align::<$t>());
+        )*
+    };
+}
+
+ctype_sign_sz_align!(
+    core::ffi::c_schar,  SCHAR;
+    core::ffi::c_uchar,  UCHAR;
+    core::ffi::c_short,  SHORT;
+    core::ffi::c_ushort, USHORT;
+
+    core::ffi::c_int,    INT;
+    core::ffi::c_uint,   UINT;
+    core::ffi::c_long,   LONG;
+    core::ffi::c_ulong,  ULONG;
+
+    core::ffi::c_longlong,  LONGLONG;
+    core::ffi::c_ulonglong, ULONGLONG;
+);
+
+/// Generates an implementation of [`HasFitsDataType`] for integer type `$t`,
+/// making sure we match `$t` with an equivalent C type.
+macro_rules! has_fits_data_type_int {
+    ($t:ty) => {
+        impl HasFitsDataType for $t {
+            const FITS_DATA_TYPE: DataType = {
+                // we use $t::MIN == 0 here and in ctype_sign_sz_align! to distinguish between signed and unsigned types
+
+                #[allow(unreachable_patterns)]
+                match (<$t>::MIN == 0, size_align::<$t>()) {
+                    UINT => DataType::TUINT,
+                    USHORT => DataType::TUSHORT,
+                    UCHAR => DataType::TBYTE,
+                    ULONG => DataType::TULONG,
+                    ULONGLONG => DataType::TULONGLONG,
+
+                    INT => DataType::TINT,
+                    SHORT => DataType::TSHORT,
+                    SCHAR => DataType::TSBYTE,
+                    LONG => DataType::TLONG,
+                    LONGLONG => DataType::TLONGLONG,
+
+                    _ => panic!(concat!(
+                        "Type ",
+                        stringify!($t),
+                        " does not have a corresponding DataType"
+                    )),
+                }
+            };
+        }
+    };
+}
+
+has_fits_data_type_int!(u8);
+has_fits_data_type_int!(u16);
+has_fits_data_type_int!(u32);
+has_fits_data_type_int!(u64);
+has_fits_data_type_int!(i8);
+has_fits_data_type_int!(i16);
+has_fits_data_type_int!(i32);
+has_fits_data_type_int!(i64);
+
+/// Generates an implementation of [`HasFitsDataType`] for floating-point type `$t`,
+/// making sure we match `$t` with an equivalent C type.
+macro_rules! has_fits_data_type_floating {
+    ($t:ty) => {
+        impl HasFitsDataType for $t {
+            const FITS_DATA_TYPE: DataType = {
+                use core::ffi::{c_double, c_float};
+
+                const FLOAT: (usize, usize) = size_align::<c_float>();
+                const DOUBLE: (usize, usize) = size_align::<c_double>();
+
+                #[allow(unreachable_patterns)]
+                match size_align::<$t>() {
+                    DOUBLE => DataType::TDOUBLE,
+                    FLOAT => DataType::TFLOAT,
+                    _ => panic!(concat!(
+                        "Type ",
+                        stringify!($t),
+                        " does not have a corresponding DataType"
+                    )),
+                }
+            };
+        }
+    };
+}
+
+has_fits_data_type_floating!(f32);
+has_fits_data_type_floating!(f64);
+
 #[cfg(test)]
 mod test {
     use crate::fitsfile::{CaseSensitivity, FileOpenMode};


### PR DESCRIPTION
This pull request fixes a bug found in use, as well as several others that are similar. Our team tried to write header entries with 64-bit values on a 32-bit ARM system, but found that the high-order 32 bits were stripped off in the resulting FITS file.

Investigation found that `fitsio`, when using write_key with a 64-bit {signed, unsigned} integer, was using `DataType::{TLONG, TULONG}`. This instructs CFITSIO to treat the passed-in value as a C {`long`, `unsigned long`}.

On some systems, C `long` is 64 bits long; this is *not* the case on 32-bit ARM however, where `long` is 32 bits, causing only 32 bits of the value to be written.

This pull request does not try to manually match Rust types to C types ABI-by-ABI, but instead associates each relevant integer and floating-point type with a value of `DataType` that is determined at compile-time to be an equivalent C type; the new `HasFitsDataType` trait is used to store the results.

I do not claim to have found all possible mismatches of this type, but I think I found all involving `DataType`.