### PR TITLE
Fixes to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM rust:1.60.0-slim-buster
+FROM rust:1.60.0-slim-bullseye
 
 RUN apt-get update && \
     apt-get -yq dist-upgrade && \
     apt-get install -yq --no-install-recommends \
         libcfitsio-dev \
         pkg-config \
-        libclang-3.8-dev \
+        libclang-19-dev \
         build-essential \
         cmake \
         clang \
@@ -17,7 +17,10 @@ RUN apt-get update && \
 
 RUN rustup update && \
     rustup install stable && \
-    rustup install nightly
+    rustup install nightly && \
+    rustup component add --toolchain stable clippy
+
+RUN cargo +stable install --locked cargo-nextest
 
 VOLUME ["/project"]
 WORKDIR "/project"


### PR DESCRIPTION
As of earlier today, the Dockerfile failed to build for two reasons:

* The Debian repos for `buster` are no longer available
* When switching to Debian `bullseye`, `libclang-3.8-dev` is not available

This pull request fixes both by switching the base image from `rust:1.60.0-slim-buster` to `rust:1.60.0-slim-bullseye` and changing the version of `libclang` installed.

In addition, once the image _is_ built, when trying to run `cargo xtask test -t all`, testing fails because neither Clippy nor `cargo-nextest` is installed in the container yet. This pull request installs them as part of the image build.