### PR TITLE
Fixed `ColumnDataType` variant used for 64-bit data in `ColumnIterator`

### DIFF
--- a/fitsio/src/tables.rs
+++ b/fitsio/src/tables.rs
@@ -868,7 +868,7 @@ impl Iterator for ColumnIterator<'_> {
                         data,
                     })
                     .ok(),
-                ColumnDataType::Long => i64::read_col(self.fits_file, current_name)
+                ColumnDataType::LongLong => i64::read_col(self.fits_file, current_name)
                     .map(|data| Column::Int64 {
                         name: current_name.to_string(),
                         data,


### PR DESCRIPTION
Currently, `ColumnDataType::Long` is being treated as the relevant enum variant for `i64` data. However, the [<tt>TFORM<i>n</i></tt> type](https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf#subsubsection.7.3.2) of `'K'` is mapped to `ColumnDataType::LongLong` ([FITS-to-enum](https://github.com/simonrw/rust-fitsio/blob/e5b305a0ceae05bc7f6c637339248bdb7f4ff2dc/fitsio/src/tables.rs#L744), [enum-to-FITS](https://github.com/simonrw/rust-fitsio/blob/e5b305a0ceae05bc7f6c637339248bdb7f4ff2dc/fitsio/src/tables.rs#L685)), not `ColumnDataType::Long`.

This pull request fixes the variant used.