### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fitsio"
-version = "0.21.9"
+version = "0.21.10"
 dependencies = [
  "criterion",
  "fitsio-derive",
@@ -1501,7 +1501,7 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xtask"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "shlex",

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Or pin a specific version:
 
 ```toml
 [dependencies]
-fitsio = "0.21.9"
+fitsio = "0.21.10"
 ```
 
 This repository contains `fitsio-sys-bindgen` which generates the C
@@ -98,7 +98,7 @@ or use from your `Cargo.toml` as such:
 
 ```toml
 [dependencies]
-fitsio = "0.21.9"
+fitsio = "0.21.10"
 ```
 
 ## Documentation

--- a/fitsio/CHANGELOG.md
+++ b/fitsio/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.10](https://github.com/simonrw/rust-fitsio/compare/fitsio-v0.21.9...fitsio-v0.21.10) - 2026-04-20
+
+### Other
+
+- Fixed `ColumnDataType` variant used for 64-bit data in `ColumnIterator` ([#444](https://github.com/simonrw/rust-fitsio/pull/444))
+- Miscellaneous fixes for Rust type-to-CFITSIO type mappings ([#442](https://github.com/simonrw/rust-fitsio/pull/442))
+- *(deps)* update criterion requirement from 0.7.0 to 0.8.0 in /fitsio in the cargo-packages group ([#425](https://github.com/simonrw/rust-fitsio/pull/425))
+- *(deps)* update ndarray requirement from 0.16.0 to 0.17.1 in /fitsio in the cargo-packages group ([#422](https://github.com/simonrw/rust-fitsio/pull/422))
+
 ## [0.21.9](https://github.com/simonrw/rust-fitsio/compare/fitsio-v0.21.8...fitsio-v0.21.9) - 2025-10-22
 
 ### Added

--- a/fitsio/Cargo.toml
+++ b/fitsio/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "fitsio"
 readme = "README.md"
 repository = "https://github.com/simonrw/rust-fitsio"
-version = "0.21.9"
+version = "0.21.10"
 rust-version = "1.58.0"
 
 [package.metadata.release]

--- a/fitsio/src/lib.rs
+++ b/fitsio/src/lib.rs
@@ -1055,7 +1055,7 @@ let _hdu = t.hdu(hdu_num).unwrap();
 [threadsafe-fits-file]: threadsafe_fitsfile/struct.ThreadsafeFitsFile.html
 */
 
-#![doc(html_root_url = "https://docs.rs/fitsio/0.21.9")]
+#![doc(html_root_url = "https://docs.rs/fitsio/0.21.10")]
 #![deny(missing_docs)]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]

--- a/xtask/CHANGELOG.md
+++ b/xtask/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/simonrw/rust-fitsio/compare/xtask-v0.1.0...xtask-v0.1.1) - 2026-04-20
+
+### Other
+
+- Swap bin/test for cargo xtask test ([#429](https://github.com/simonrw/rust-fitsio/pull/429))

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `fitsio`: 0.21.9 -> 0.21.10 (✓ API compatible changes)
* `xtask`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `fitsio`

<blockquote>

## [0.21.10](https://github.com/simonrw/rust-fitsio/compare/fitsio-v0.21.9...fitsio-v0.21.10) - 2026-04-20

### Other

- Fixed `ColumnDataType` variant used for 64-bit data in `ColumnIterator` ([#444](https://github.com/simonrw/rust-fitsio/pull/444))
- Miscellaneous fixes for Rust type-to-CFITSIO type mappings ([#442](https://github.com/simonrw/rust-fitsio/pull/442))
- *(deps)* update criterion requirement from 0.7.0 to 0.8.0 in /fitsio in the cargo-packages group ([#425](https://github.com/simonrw/rust-fitsio/pull/425))
- *(deps)* update ndarray requirement from 0.16.0 to 0.17.1 in /fitsio in the cargo-packages group ([#422](https://github.com/simonrw/rust-fitsio/pull/422))
</blockquote>

## `xtask`

<blockquote>

## [0.1.1](https://github.com/simonrw/rust-fitsio/compare/xtask-v0.1.0...xtask-v0.1.1) - 2026-04-20

### Other

- Swap bin/test for cargo xtask test ([#429](https://github.com/simonrw/rust-fitsio/pull/429))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).