### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fitsio"
-version = "0.21.10"
+version = "0.22.0"
 dependencies = [
  "criterion",
  "fitsio-derive",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "fitsio-sys"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "autotools",
  "bindgen",

--- a/fitsio-sys/CHANGELOG.md
+++ b/fitsio-sys/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+## [0.6.0](https://github.com/simonrw/rust-fitsio/compare/fitsio-sys-v0.5.7...fitsio-sys-v0.6.0) - 2026-05-23
+
+### Fixed
+
+- [**breaking**] bump MSRV to resolve nightly dependency failure ([#451](https://github.com/simonrw/rust-fitsio/pull/451))
+
 ## [0.5.7](https://github.com/simonrw/rust-fitsio/compare/fitsio-sys-v0.5.6...fitsio-sys-v0.5.7) - 2025-10-22
 
 ### Added

--- a/fitsio-sys/Cargo.toml
+++ b/fitsio-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fitsio-sys"
-version = "0.5.7"
+version = "0.6.0"
 edition = "2018"
 authors = ["Simon Walker <s.r.walker101@googlemail.com>"]
 description = "FFI wrapper around cfitsio"

--- a/fitsio/CHANGELOG.md
+++ b/fitsio/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/simonrw/rust-fitsio/compare/fitsio-v0.21.10...fitsio-v0.22.0) - 2026-05-23
+
+### Fixed
+
+- [**breaking**] bump MSRV to resolve nightly dependency failure ([#451](https://github.com/simonrw/rust-fitsio/pull/451))
+
 ## [0.21.10](https://github.com/simonrw/rust-fitsio/compare/fitsio-v0.21.9...fitsio-v0.21.10) - 2026-04-20
 
 ### Other

--- a/fitsio/Cargo.toml
+++ b/fitsio/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "fitsio"
 readme = "README.md"
 repository = "https://github.com/simonrw/rust-fitsio"
-version = "0.21.10"
+version = "0.22.0"
 rust-version = "1.63.0"
 
 [package.metadata.release]
@@ -23,7 +23,7 @@ features = ["array"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-fitsio-sys = { version = "0.5", path = "../fitsio-sys" }
+fitsio-sys = { version = "0.6", path = "../fitsio-sys" }
 libc = "0.2.44"
 ndarray = { version = "0.17.1", optional = true }
 


### PR DESCRIPTION



## 🤖 New release

* `fitsio-sys`: 0.5.7 -> 0.6.0 (✓ API compatible changes)
* `fitsio`: 0.21.10 -> 0.22.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `fitsio-sys`

<blockquote>

## [0.6.0](https://github.com/simonrw/rust-fitsio/compare/fitsio-sys-v0.5.7...fitsio-sys-v0.6.0) - 2026-05-23

### Fixed

- [**breaking**] bump MSRV to resolve nightly dependency failure ([#451](https://github.com/simonrw/rust-fitsio/pull/451))
</blockquote>

## `fitsio`

<blockquote>

## [0.22.0](https://github.com/simonrw/rust-fitsio/compare/fitsio-v0.21.10...fitsio-v0.22.0) - 2026-05-23

### Fixed

- [**breaking**] bump MSRV to resolve nightly dependency failure ([#451](https://github.com/simonrw/rust-fitsio/pull/451))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).